### PR TITLE
fixing error with Django > 1.9: object has no attribute 'assignment_tag'.

### DIFF
--- a/admin_menu/templatetags/custom_admin_css.py
+++ b/admin_menu/templatetags/custom_admin_css.py
@@ -61,7 +61,7 @@ def get_sass_source():
     )
 
 
-@register.assignment_tag
+@register.simple_tag
 def get_custom_admin_css():
     global _compiled_sass
     if not _compiled_sass:

--- a/admin_menu/templatetags/custom_admin_logo.py
+++ b/admin_menu/templatetags/custom_admin_logo.py
@@ -4,6 +4,6 @@ from django import template
 register = template.Library()
 
 
-@register.assignment_tag
+@register.simple_tag
 def get_custom_logo():
     return getattr(settings, 'ADMIN_LOGO', None)

--- a/admin_menu/templatetags/custom_admin_menu.py
+++ b/admin_menu/templatetags/custom_admin_menu.py
@@ -126,7 +126,7 @@ def make_menu_group(title, children=None, weight=None):
     return MenuGroup(title=title, children=children, weight=weight or get_group_weight(title))
 
 
-@register.assignment_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def get_admin_menu(context):
     request = context['request']
     apps = get_app_list(context, True)


### PR DESCRIPTION
It is probably caused by deprecation and removing "assignment_tag" from Django > 1.9